### PR TITLE
Missing requirement in example code in README.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -11,6 +11,7 @@ $ npm install stop
 ## Example Usage
 
 ```js
+var url = require('url');
 var stop = require('stop');
 
 stop.getWebsiteStream('http://example.com', {


### PR DESCRIPTION
Hello,

Thanks for `stop.js`!

In the README example code the `url` module is referenced but not required—
this gives an error when running the code as provided.

Maybe this is because you want to keep the example minimal?
It seems more clear to me to include it in the snippet, so one can copy & paste immediately.

Cheers,
